### PR TITLE
chore(root): remove redundant ci step

### DIFF
--- a/.github/workflows/PR-checks.yml
+++ b/.github/workflows/PR-checks.yml
@@ -19,15 +19,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
-        with:
-          path: |
-            packages/*/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node
-
       - name: Install dependencies
         run: |
           npm ci


### PR DESCRIPTION
## Summary of the changes
Generating a cache from packages/** doesnt exist in test app.

## Related issue
We can alternatively cache the root lock file.